### PR TITLE
test: Change `RefreshDatabase` to `LazilyRefreshDatabase`

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
 /*
 |--------------------------------------------------------------------------
@@ -15,7 +15,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 */
 
 uses(Tests\TestCase::class)->in('Feature', 'Unit');
-uses(RefreshDatabase::class)->in('Feature', 'Unit');
+uses(LazilyRefreshDatabase::class)->in('Feature', 'Unit');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes the `RefreshDatabase` use to `LazilyRefreshDatabase` so that way it only refresh the database if the tests need to use the database.

This was introduced on v8.62.

Hope that helps.